### PR TITLE
Fix Julia 0.5 breakages

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
 julia 0.5
-Compat
+Compat 0.17

--- a/src/EndpointRanges.jl
+++ b/src/EndpointRanges.jl
@@ -73,11 +73,12 @@ function Base.getindex(r::LinSpace, s::EndpointRange)
     getindex(r, newindex(indices1(r), s))
 end
 
-# @inline function Base._getindex{T,N}(l::IndexLinear, A::AbstractArray{T,N}, I::Vararg{Union{Real, AbstractArray, Colon, EndpointRange},N})
-#     Base._getindex(l, A, newindices(indices(A), I)...)
-# end
 
 if VERSION < v"0.6.0-dev.1932"
+    @inline function Base._getindex{T,N}(l::Base.LinearIndexing, A::AbstractArray{T,N}, I::Vararg{Union{Real, AbstractArray, Colon, EndpointRange},N})
+        Base._getindex(l, A, newindices(indices(A), I)...)
+    end
+
     @inline function Base.view{T,N}(A::AbstractArray{T,N}, I::Vararg{Union{ViewIndex,EndpointRange},N})
         view(A, newindices(indices(A), I)...)
     end


### PR DESCRIPTION
Minutes ago I accidentally pushed 02b5583f8b5b2fe07688ddcc84f9d83bf7bc829b directly to master, and it broke 0.5. This should fix it.