### PR TITLE
fix package on 1.9 with the removal of the internal `_maybetail`

### DIFF
--- a/src/EndpointRanges.jl
+++ b/src/EndpointRanges.jl
@@ -80,7 +80,7 @@ end
 
 
 @inline function Base.to_indices(A, inds, I::Tuple{Union{Endpoint, EndpointRange}, Vararg{Any}})
-    (newindex(inds[1], I[1]), to_indices(A, Base._maybetail(inds), Base.tail(I))...)
+    (newindex(inds[1], I[1]), to_indices(A, inds[2:end], Base.tail(I))...)
 end
 
 @inline newindices(indsA, inds) = (newindex(indsA[1], inds[1]), newindices(tail(indsA), tail(inds))...)


### PR DESCRIPTION
`_maybetail` was removed in https://github.com/JuliaLang/julia/pull/45672 and https://github.com/JuliaLang/julia/issues/23822#issuecomment-623703610 says that `[2:end]` is currently equivalent of that.

Edit: Just saw https://github.com/JuliaArrays/EndpointRanges.jl/pull/25 ...